### PR TITLE
Added missing package dependency to Dockerfile

### DIFF
--- a/emulator-oc-cassini/Dockerfile
+++ b/emulator-oc-cassini/Dockerfile
@@ -3,7 +3,7 @@ COPY yang /root/yang
 COPY config /root/config
 COPY script /root/script
 RUN apt-get update && apt-get upgrade -y \
-    && apt-get install software-properties-common build-essential openssl libssl-dev libpcre3 libpcre3-dev git make cmake bison flex pkg-config graphviz doxygen valgrind zlib1g zlib1g-dev libev-dev libavl-dev libprotobuf-c-dev protobuf-c-compiler swig python-dev lua5.2 vim net-tools libcurl4-openssl-dev man -y \
+    && apt-get install software-properties-common build-essential openssl libssl-dev libpcre3 libpcre3-dev git make cmake bison flex pkg-config graphviz doxygen valgrind zlib1g zlib1g-dev libev-dev libavl-dev libprotobuf-c-dev protobuf-c-compiler swig python-dev lua5.2 vim net-tools libcurl4-openssl-dev lib32ncurses5-dev man -y \
     && echo "export LD_LIBRARY_PATH=/lib:/usr/lib:/usr/local/lib" >> ~/.bashrc \
     && export LD_LIBRARY_PATH=/lib:/usr/lib:/usr/local/lib \
     && cd ~ && git clone http://git.libssh.org/projects/libssh.git \


### PR DESCRIPTION
When building the two OpenConfig emulators with `docker-compose up -d`, Docker fails to build the image. There is a compilation error while installing `netconf-console` ([line 39](https://github.com/opennetworkinglab/ODTN-emulator/blob/master/emulator-oc-cassini/Dockerfile#L39))

I have discovered that installing the package `lib32ncurses5-dev` fixes this problem.